### PR TITLE
Use system binaries for Zen Browser

### DIFF
--- a/assets/config/browsers/zen.yml
+++ b/assets/config/browsers/zen.yml
@@ -1,5 +1,8 @@
 name: Zen
 flatpak: app.zen_browser.zen
+system_bin:
+  - zen-browser
+  - zen-browser-bin
 can_isolate: true
 desktop_file_name_prefix: app.zen_browser.zen.zen
 base: firefox


### PR DESCRIPTION
Will use `zen-browser` and `zen-browser-bin` binaries.

Tested using
- COPR: https://copr.fedorainfracloud.org/coprs/sneexy/zen-browser/