### PR TITLE
Fix blurry icons

### DIFF
--- a/workspaces/app/src/application/pages/web_apps/web_app_view/icon_picker/icon_fetcher.rs
+++ b/workspaces/app/src/application/pages/web_apps/web_app_view/icon_picker/icon_fetcher.rs
@@ -112,7 +112,7 @@ impl IconFetcher {
 
     fn set_icon_urls_from_html(&mut self, html_fragment: &Html, url: &Url) {
         let Ok(icon_selector) =
-            Selector::parse("link[rel~=\"icon\"], link[rel~=\"shortcut\"][rel~=\"icon\"]")
+            Selector::parse("link[rel~=\"apple-touch-icon\"], link[rel~=\"icon\"], link[rel~=\"shortcut\"][rel~=\"icon\"]")
         else {
             return;
         };

--- a/workspaces/app/src/application/pages/web_apps/web_app_view/icon_picker/icon_fetcher.rs
+++ b/workspaces/app/src/application/pages/web_apps/web_app_view/icon_picker/icon_fetcher.rs
@@ -111,9 +111,9 @@ impl IconFetcher {
     }
 
     fn set_icon_urls_from_html(&mut self, html_fragment: &Html, url: &Url) {
-        let Ok(icon_selector) =
-            Selector::parse("link[rel~=\"apple-touch-icon\"], link[rel~=\"icon\"], link[rel~=\"shortcut\"][rel~=\"icon\"]")
-        else {
+        let Ok(icon_selector) = Selector::parse(
+            "link[rel~=\"apple-touch-icon\"], link[rel~=\"icon\"], link[rel~=\"shortcut\"][rel~=\"icon\"]",
+        ) else {
             return;
         };
 

--- a/workspaces/common/src/fetch.rs
+++ b/workspaces/common/src/fetch.rs
@@ -35,7 +35,8 @@ impl Fetch {
             let mut call = agent_clone.get(url_clone).call()?;
             let body = call.body_mut();
             let mimetype = body.mime_type().map(std::string::ToString::to_string);
-            let response = body.read_to_string()?;
+            let text = body.read_to_vec().unwrap();
+            let response = String::from_utf8_lossy(&text).to_string();
             Ok((response, mimetype))
         })
         .await

--- a/workspaces/common/src/fetch.rs
+++ b/workspaces/common/src/fetch.rs
@@ -35,7 +35,7 @@ impl Fetch {
             let mut call = agent_clone.get(url_clone).call()?;
             let body = call.body_mut();
             let mimetype = body.mime_type().map(std::string::ToString::to_string);
-            let text = body.read_to_vec().unwrap();
+            let text = body.read_to_vec()?;
             let response = String::from_utf8_lossy(&text).to_string();
             Ok((response, mimetype))
         })


### PR DESCRIPTION
I'm improving the quality of the icons to provide high resolution version when possible.

The pull request is about fixing two aspects:
- the manifest files not in utf-8 now are not working so we are missing high res icons for mainstream services such as Google Maps
- not every site is using manifest files and in this case the hires icon is not managed (For example Wikipedia)

The general goal of this pull request is to have icons with good resolution because I've tested different popular sites and for different reasons the proposed icons have low quality